### PR TITLE
Remove unused FinancialCategories import

### DIFF
--- a/src/components/MappingTable.tsx
+++ b/src/components/MappingTable.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Search, Download, Save, RotateCcw } from "lucide-react";
-import { AccountMapping, FinancialCategories } from "@/types/financial";
+import { AccountMapping } from "@/types/financial";
 
 interface MappingTableProps {
   mappings: AccountMapping[];


### PR DESCRIPTION
## Summary
- prune `FinancialCategories` from `MappingTable.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `tsc --noUnusedLocals --noUnusedParameters -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6869090de18c832c89a8fb712a7cc566